### PR TITLE
Lower smallnet threshold with updated eval divisors

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -46,7 +46,7 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 bool Eval::use_smallnet(const Position& pos) {
     int simpleEval = simple_eval(pos, pos.side_to_move());
-    return std::abs(simpleEval) > 1126 + 6 * pos.count<PAWN>();
+    return std::abs(simpleEval) > 1018 + 5 * pos.count<PAWN>();
 }
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
@@ -73,8 +73,8 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     }
 
     // Blend optimism and eval with nnue complexity and material imbalance
-    optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 584;
-    nnue -= nnue * (nnueComplexity * 5 / 3) / 32395;
+    optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 620;
+    nnue -= nnue * (nnueComplexity * 5 / 3) / 32082;
 
     v = (nnue
            * (32961 + 381 * pos.count<PAWN>() + 349 * pos.count<KNIGHT>()
@@ -82,7 +82,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
          + optimism
              * (4835 + 136 * pos.count<PAWN>() + 375 * pos.count<KNIGHT>()
                 + 403 * pos.count<BISHOP>() + 628 * pos.count<ROOK>() + 1124 * pos.count<QUEEN>()))
-      / 32768;
+      / 36860;
 
     // Damp down the evaluation linearly when shuffling
     v = v * (204 - pos.rule50_count()) / 208;


### PR DESCRIPTION
Params found after 30k spsa games at 60+0.6, with initial values from 64k spsa games at 45+0.45

First spsa with 64k / 120k games at 45+0.45:
https://tests.stockfishchess.org/tests/view/664a561b5fc7b70b8817c663 https://tests.stockfishchess.org/tests/view/664ae88e830eb9f8866146f9

Second spsa with 30k / 120k games at 60+0.6:
https://tests.stockfishchess.org/tests/view/664be227830eb9f886615a36

Values found at 10k games at 60+0.6 also passed STC and LTC: https://tests.stockfishchess.org/tests/view/664bf4bd830eb9f886615a72 https://tests.stockfishchess.org/tests/view/664c0905830eb9f886615abf

Passed STC:
https://tests.stockfishchess.org/tests/view/664c139e830eb9f886615af2
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 69408 W: 18216 L: 17842 D: 33350
Ptnml(0-2): 257, 8275, 17401, 8379, 392

Passed LTC:
https://tests.stockfishchess.org/tests/view/664cdaf7830eb9f886616a24
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 35466 W: 9075 L: 8758 D: 17633
Ptnml(0-2): 27, 3783, 9794, 4104, 25

closes https://github.com/official-stockfish/Stockfish/pull/5280

bench 1301287